### PR TITLE
fix: close ytdlp file after download finish

### DIFF
--- a/internal/service/ytdlp/auto_download.go
+++ b/internal/service/ytdlp/auto_download.go
@@ -105,6 +105,7 @@ func autoDownloadExec() {
 		log.Printf(colors.ToRed("初始化二进制文件路径失败: %s, err: %v"), execPath, err)
 		return
 	}
+	defer execFile.Close()
 	io.Copy(execFile, resp.Body)
 
 	// 标记就绪状态


### PR DESCRIPTION
自动下载 yt-dlp 完成后，关闭文件资源，解决文件占用