### PR TITLE
perf: change youtube cache update fail strategy

### DIFF
--- a/internal/service/resolve/handler/youtube.go
+++ b/internal/service/resolve/handler/youtube.go
@@ -235,9 +235,12 @@ func (yc *youtubeCacher) UpdateAll() {
 		_, err := yc.CacheM3U(chId, formatCode)
 		if err != nil {
 			failCnt++
-		} else {
-			successCnt++
+			toRemoves = append(toRemoves, key)
+			removeCnt++
+			continue
 		}
+
+		successCnt++
 	}
 
 	if len(toRemoves) == 0 {


### PR DESCRIPTION
youtube 缓存更新失败时，直接从缓存中移除