### PR TITLE
fix: use custom headers to request sub m3u

### DIFF
--- a/internal/service/resolve/handler/remote_m3u.go
+++ b/internal/service/resolve/handler/remote_m3u.go
@@ -40,7 +40,7 @@ func (h *remoteM3UHandler) Handle(params resolve.HandleParams) (resolve.HandleRe
 	}
 
 	// 请求远程 m3u 文本
-	_, resp, err := h.cc.Request(http.MethodGet, url, nil, nil, true)
+	_, resp, err := h.cc.Request(http.MethodGet, url, params.Headers, nil, true)
 	if err != nil {
 		return resolve.HandleResult{}, fmt.Errorf("请求远程地址失败: %v", err)
 	}


### PR DESCRIPTION
请求订阅 m3u 时使用自定义的请求头